### PR TITLE
Convert checkDeps(action=ask) into action=stop without renv

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '618400'
+ValidationKey: '638253'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piamenv: Package environment support for PIAM",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "<p>Enables easier management of package environments, based on renv and Python venv.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamenv
 Title: Package environment support for PIAM
-Version: 0.3.2
-Date: 2022-11-29
+Version: 0.3.3
+Date: 2022-12-15
 Authors@R:
     person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = c("aut", "cre"))
 Description: Enables easier management of package environments, based on renv and Python venv.
@@ -17,4 +17,4 @@ Suggests:
     covr,
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 .PHONY: help build check test lint format
 .DEFAULT_GOAL = help
 
+# extracts the help text and formats it nicely
+HELP_PARSING = 'm <- readLines("Makefile");\
+				m <- grep("\#\#", m, value=TRUE);\
+				command <- sub("^([^ ]*) *\#\#(.*)", "\\1", m);\
+				help <- sub("^([^ ]*) *\#\#(.*)", "\\2", m);\
+				cat(sprintf("%-8s%s", command, help), sep="\n")'
+
 help:           ## Show this help.
-	@sed -e '/##/ !d' -e '/sed/ d' -e 's/^\([^ ]*\) *##\(.*\)/\1^\2/' \
-		$(MAKEFILE_LIST) | column -ts '^'
+	@Rscript -e $(HELP_PARSING)
 
 build:          ## Build the package using lucode2::buildLibrary()
 	Rscript -e 'lucode2::buildLibrary()'

--- a/R/checkDeps.R
+++ b/R/checkDeps.R
@@ -13,7 +13,7 @@
 #'   - `"note"`: Issue a message with the unmet dependencies.
 #'   - `"pass"`: Do nothing, just return invisibly.
 #'   - `"ask"`: Ask the user whether to auto-fix missing dependencies. Requires an active renv.
-#'              Will also write renv.lock
+#'              Will also write renv.lock. If no active renv is found, stops instead.
 #' @return Invisibly, a named list of strings indicating whether each package
 #'   requirement is met (`"TRUE"`) or not, in which case the reason is stated.
 #'
@@ -28,6 +28,9 @@ checkDeps <- function(descriptionFile = ".",
                       action = "stop") {
   stopifnot(all(dependencyTypes %in% c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")))
   stopifnot(action %in% c("stop", "warn", "note", "pass", "ask"))
+  if (action == "ask" && is.null(renv::project())) {
+    action <- "stop"
+  }
 
   if (action == "ask") {
     installedPackages <- fixDeps(ask = TRUE, checkDeps(descriptionFile = descriptionFile,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package environment support for PIAM
 
-R package **piamenv**, version **0.3.2**
+R package **piamenv**, version **0.3.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamenv)](https://cran.r-project.org/package=piamenv)  [![R build status](https://github.com/pik-piam/piamenv/workflows/check/badge.svg)](https://github.com/pik-piam/piamenv/actions) [![codecov](https://codecov.io/gh/pik-piam/piamenv/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamenv) [![r-universe](https://pik-piam.r-universe.dev/badges/piamenv)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piamenv** in publications use:
 
-Führlich P (2022). _piamenv: Package environment support for PIAM_. R package version 0.3.2, <https://github.com/pik-piam/piamenv>.
+Führlich P (2022). _piamenv: Package environment support for PIAM_. R package version 0.3.3, <https://github.com/pik-piam/piamenv>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {piamenv: Package environment support for PIAM},
   author = {Pascal Führlich},
   year = {2022},
-  note = {R package version 0.3.2},
+  note = {R package version 0.3.3},
   url = {https://github.com/pik-piam/piamenv},
 }
 ```

--- a/man/checkDeps.Rd
+++ b/man/checkDeps.Rd
@@ -24,7 +24,7 @@ subset of \code{c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")}.}
 \item \code{"note"}: Issue a message with the unmet dependencies.
 \item \code{"pass"}: Do nothing, just return invisibly.
 \item \code{"ask"}: Ask the user whether to auto-fix missing dependencies. Requires an active renv.
-Will also write renv.lock
+Will also write renv.lock. If no active renv is found, stops instead.
 }}
 }
 \value{


### PR DESCRIPTION
Hi,

with this PR, `checkDeps(action="ask")` acts like `checkDeps(action="stop")` if no renv is active. So, instead of:
```
Error in fixDeps(ask = TRUE, checkDeps(descriptionFile = descriptionFile,  : 
  No renv active. Try starting the R session in the project root.
```
you get an error like:
```
Error in piamenv::checkDeps(action = "ask") : 
  gms >= 0.21.0 is required, but 0.4.0 is installed - please update: gms
Execution halted
```
which is a lot more helpful.