### PR TITLE
keep renv from updating itself when there is nothing to revert

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,7 +1,8 @@
-ValidationKey: '984750'
+ValidationKey: '1008576'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 AcceptedNotes: ~
 allowLinterWarnings: no
+enforceVersionUpdate: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamenv: Package environment support for PIAM'
-version: 0.5.0
-date-released: '2023-12-04'
+version: 0.5.1
+date-released: '2024-02-23'
 abstract: Enables easier management of package environments, based on renv and Python
   venv.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamenv
 Title: Package environment support for PIAM
-Version: 0.5.0
-Date: 2023-12-04
+Version: 0.5.1
+Date: 2024-02-23
 Authors@R:
     person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = c("aut", "cre"))
 Description: Enables easier management of package environments, based on renv and Python venv.
@@ -17,4 +17,4 @@ Suggests:
     covr,
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/revertDevelopmentVersions.R
+++ b/R/revertDevelopmentVersions.R
@@ -24,5 +24,7 @@ revertDevelopmentVersions <- function() {
                   return(b)
               }))
 
-  invisible(renv::install(paste(names(x), x, sep = "@"), prompt = FALSE))
+  if (length(x)) {
+    invisible(renv::install(paste(names(x), x, sep = "@"), prompt = FALSE))
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package environment support for PIAM
 
-R package **piamenv**, version **0.5.0**
+R package **piamenv**, version **0.5.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamenv)](https://cran.r-project.org/package=piamenv)  [![R build status](https://github.com/pik-piam/piamenv/workflows/check/badge.svg)](https://github.com/pik-piam/piamenv/actions) [![codecov](https://codecov.io/gh/pik-piam/piamenv/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamenv) [![r-universe](https://pik-piam.r-universe.dev/badges/piamenv)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piamenv** in publications use:
 
-Führlich P (2023). _piamenv: Package environment support for PIAM_. R package version 0.5.0, <https://github.com/pik-piam/piamenv>.
+Führlich P (2024). _piamenv: Package environment support for PIAM_. R package version 0.5.1, <https://github.com/pik-piam/piamenv>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,8 +46,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {piamenv: Package environment support for PIAM},
   author = {Pascal Führlich},
-  year = {2023},
-  note = {R package version 0.5.0},
+  year = {2024},
+  note = {R package version 0.5.1},
   url = {https://github.com/pik-piam/piamenv},
 }
 ```


### PR DESCRIPTION
Otherwise renv keeps installing a current version over 0.16.0 shipping with REMIND.