### PR TITLE
allow to exclude packages from updateRenv

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1053587'
+ValidationKey: '1078056'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamenv: Package environment support for PIAM'
-version: 0.5.3
-date-released: '2024-06-05'
+version: 0.5.4
+date-released: '2024-08-29'
 abstract: Enables easier management of package environments, based on renv and Python
   venv.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamenv
 Title: Package environment support for PIAM
-Version: 0.5.3
-Date: 2024-06-05
+Version: 0.5.4
+Date: 2024-08-29
 Authors@R:
     person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = c("aut", "cre"))
 Description: Enables easier management of package environments, based on renv and Python venv.
@@ -17,4 +17,4 @@ Suggests:
     covr,
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/updateRenv.R
+++ b/R/updateRenv.R
@@ -3,14 +3,14 @@
 #' Update all PIK-PIAM packages in the current renv, write renv.lock into archive.
 #'
 #' @return Invisibly, the return value of renv::update.
-#'
+#' @param exclude vector of packages not to be updated
 #' @author Pascal Sauer
 #' @export
-updateRenv <- function() {
+updateRenv <- function(exclude = NULL) {
   stopifnot(`No renv active. Try starting the R session in the project root.` = !is.null(renv::project()))
 
   installedPiamPackages <- intersect(utils::installed.packages()[, "Package"], piamPackages())
-  installedUpdates <- renv::update(installedPiamPackages, prompt = FALSE)
+  installedUpdates <- renv::update(setdiff(installedPiamPackages, exclude), prompt = FALSE)
 
   archiveRenv()
   return(invisible(installedUpdates))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package environment support for PIAM
 
-R package **piamenv**, version **0.5.3**
+R package **piamenv**, version **0.5.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamenv)](https://cran.r-project.org/package=piamenv)  [![R build status](https://github.com/pik-piam/piamenv/workflows/check/badge.svg)](https://github.com/pik-piam/piamenv/actions) [![codecov](https://codecov.io/gh/pik-piam/piamenv/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamenv) [![r-universe](https://pik-piam.r-universe.dev/badges/piamenv)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Pascal Sauer <pascal.sauer@pik-po
 
 To cite package **piamenv** in publications use:
 
-Sauer P (2024). _piamenv: Package environment support for PIAM_. R package version 0.5.3, <https://github.com/pik-piam/piamenv>.
+Sauer P (2024). _piamenv: Package environment support for PIAM_. R package version 0.5.4, <https://github.com/pik-piam/piamenv>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {piamenv: Package environment support for PIAM},
   author = {Pascal Sauer},
   year = {2024},
-  note = {R package version 0.5.3},
+  note = {R package version 0.5.4},
   url = {https://github.com/pik-piam/piamenv},
 }
 ```

--- a/man/updateRenv.Rd
+++ b/man/updateRenv.Rd
@@ -4,7 +4,10 @@
 \alias{updateRenv}
 \title{updateRenv}
 \usage{
-updateRenv()
+updateRenv(exclude = NULL)
+}
+\arguments{
+\item{exclude}{vector of packages not to be updated}
 }
 \value{
 Invisibly, the return value of renv::update.


### PR DESCRIPTION
- add an `exclude` options analogously to `renv::update(exclude = "edgeTransport")` https://rstudio.github.io/renv/reference/update.html
- need that because REMIND master does not work with very recent edgeTransport versions