### PR TITLE
Remove tryCatch and utils::capture.output

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1431928'
+ValidationKey: '1453536'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamenv: Package environment support for PIAM'
-version: 0.7.1
-date-released: '2025-03-21'
+version: 0.7.2
+date-released: '2025-04-10'
 abstract: Enables easier management of package environments, based on renv and conda.
 authors:
 - family-names: Sauer

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamenv
 Title: Package environment support for PIAM
-Version: 0.7.1
-Date: 2025-03-21
+Version: 0.7.2
+Date: 2025-04-10
 Authors@R: c(
     person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = c("aut", "cre")),
     person("Tonn", "Rüter", , "tonn.rueter@pik-potsdam.de", role = c("aut")))

--- a/R/archiveRenv.R
+++ b/R/archiveRenv.R
@@ -14,18 +14,8 @@ archiveRenv <- function() {
 
   dir.create(dirname(archivePath), recursive = TRUE, showWarnings = FALSE)
 
-  errorMessage <- utils::capture.output({
-    snapshotSuccess <- tryCatch({
-      renv::snapshot(lockfile = archivePath, prompt = FALSE)
-      TRUE
-    },
-    error = function(error) FALSE)
-  },
-  type = "output")
+  renv::snapshot(lockfile = archivePath, prompt = FALSE)
 
-  if (!snapshotSuccess) {
-    stop(paste(errorMessage, collapse = "\n"))
-  }
   message("Lockfile written to ", archivePath)
   return(invisible(archivePath))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package environment support for PIAM
 
-R package **piamenv**, version **0.7.1**
+R package **piamenv**, version **0.7.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamenv)](https://cran.r-project.org/package=piamenv) [![R build status](https://github.com/pik-piam/piamenv/workflows/check/badge.svg)](https://github.com/pik-piam/piamenv/actions) [![codecov](https://codecov.io/gh/pik-piam/piamenv/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamenv) [![r-universe](https://pik-piam.r-universe.dev/badges/piamenv)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Pascal Sauer <pascal.sauer@pik-po
 
 To cite package **piamenv** in publications use:
 
-Sauer P, Rüter T (2025). "piamenv: Package environment support for PIAM." Version: 0.7.1, <https://github.com/pik-piam/piamenv>.
+Sauer P, Rüter T (2025). "piamenv: Package environment support for PIAM." Version: 0.7.2, <https://github.com/pik-piam/piamenv>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamenv: Package environment support for PIAM},
   author = {Pascal Sauer and Tonn Rüter},
-  date = {2025-03-21},
+  date = {2025-04-10},
   year = {2025},
   url = {https://github.com/pik-piam/piamenv},
-  note = {Version: 0.7.1},
+  note = {Version: 0.7.2},
 }
 ```


### PR DESCRIPTION
I do not know a better way to make `piamenv::archiverenv()` print the full output than removing `tryCatch` and `utils::capture.output`. If you have an idea, let me know.

This is the output `piamenv::archiverenv()` prints:

![image](https://github.com/user-attachments/assets/45b94dbf-214b-4b20-8e44-45d4c4cf2904)

This is the output `renv::snapshot()` prints:

![image](https://github.com/user-attachments/assets/78da1749-b3ea-49af-b64a-8f32ed893c48)
